### PR TITLE
feat: add localStorage persistence for todos state

### DIFF
--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Todo } from "../models/Todo";
 import { TodoList } from "./TodoList";
+import { getItem } from "../utils/LocalStorage";
 
 export const TodoApp = () => {
 
@@ -12,7 +13,26 @@ export const TodoApp = () => {
     new Todo("Söka LIA", "Kolla upp företag från listan")
   ]
 
-  const [todos, setTodos] = useState<Todo[]>(initialTodos);
+  const [todos, setTodos] = useState<Todo[]>(() => {
+    // Get from Local Storage 
+    const item = getItem("todos") as Todo[] | undefined;
+
+    // Recreate the objects from local storage
+    // 1. Create new objects using Todo Class (with correct title and text)
+    // 2. Overwrite the auto-generated values (id, completed, createdAt) with stored values
+    if (item && Array.isArray(item)) {
+      return item.map(todoData =>
+        Object.assign(new Todo(todoData.title, todoData.text), {
+          id: todoData.id,
+          completed: todoData.completed,
+          createdAt: new Date(todoData.createdAt)
+        })
+      );
+    }
+
+    // Else use pre defined list of todos
+    return initialTodos;
+  });
 
   return (
     <>

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,16 @@
+export const setItem = (key: string, value: unknown) => {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+export const getItem = (key: string) => {
+  try {
+    const item = window.localStorage.getItem(key);
+    return item ? JSON.parse(item) : undefined;
+  } catch (error) {
+    console.log(error);
+  }
+}


### PR DESCRIPTION
- Add localStorage utility functions (setItem, getItem)
- Load todos from localStorage on app initialization
- Recreate Todo objects with correct types from stored data
- Fallback to initial todos if localStorage is undefined